### PR TITLE
Fixes: Design Review

### DIFF
--- a/src/components/layout/sub-pages/Cards.js
+++ b/src/components/layout/sub-pages/Cards.js
@@ -13,7 +13,7 @@ const Card = ({ name, section, version, authors, description }) => {
         <div className="absolute top-0 right-0 py-2 px-3 bg-substrateGreen-light dark:bg-substrateGreen rounded-tr-md rounded-bl-md font-bold text-xs">
           {version}
         </div>
-        <h5 className="mb-2 truncate md:w-60 xl:w-auto 2xl:w-60">{name}</h5>
+        <h5 className="mb-2 truncate w-60">{name}</h5>
         <p className="text-sm mb-4">{authors ? authors : 'N/A'}</p>
         <p className="text-sm mb-0 h-20 line-clamp-4">{description}</p>
       </div>

--- a/src/templates/single.js
+++ b/src/templates/single.js
@@ -21,7 +21,7 @@ export default function SingularPage({ pageContext }) {
       <Section>
         <article className="lg:flex">
           <div className="lg:flex-grow mb-10 lg:mb-20 pr-4 underline-animate underline-animate-thin">
-            <div className="mb-12">
+            <div className="mb-12 capitalize">
               <NavBreadcrumb />
             </div>
             <div className="mb-12">

--- a/src/templates/sub-page.js
+++ b/src/templates/sub-page.js
@@ -36,7 +36,7 @@ export default function SingularPage({ pageContext }) {
     <Layout>
       <SEO title={section.charAt(0).toUpperCase() + section.slice(1)} />
       <Section className="mb-9">
-        <div className="mb-12">
+        <div className="mb-12 underline-animate underline-animate-thin">
           <NavBreadcrumb />
         </div>
         <div className="mb-12">


### PR DESCRIPTION
- Truncate Card title for extra long strings. 
- Capitalizing breadcrumb (single template)
- Adding underline animation on hover (sub-pages)